### PR TITLE
Fix bare structs overwriting existing struct

### DIFF
--- a/lib/yard-go/handlers.rb
+++ b/lib/yard-go/handlers.rb
@@ -41,7 +41,7 @@ module YARDGo
       process do
         return if test_file?
 
-        ns = if regular_meths.size > 0 # it's a "class"
+        ns = if regular_meths.size > 0 || P(pkg, statement.name).type == :struct # it's a "class"
           register StructObject.new(pkg, statement.name)
         else # bare struct
           register BareStructObject.new(pkg, statement.name)


### PR DESCRIPTION
If a go file is parsed containing methods for a struct which is defined in another file before the go file containing the struct's type definition the existing struct would be replaced with a bare struct. This change ensures existing structs will not be overwritten.
